### PR TITLE
チーム作成

### DIFF
--- a/src/components/CreateTeamModal.tsx
+++ b/src/components/CreateTeamModal.tsx
@@ -42,8 +42,13 @@ const CreateTeamModal: React.FC = () => {
       return alert("チーム名を入力してください");
     }
 
-    const { id } = await createTeam(teamName.toString(), userData);
-    return navigate(`/team/${id}`, { state: teamName });
+    try {
+      const { id } = await createTeam(teamName.toString(), userData);
+      return navigate(`/team/${id}`, { state: teamName });
+    } catch (error) {
+      console.error("Failed to create team:", error);
+      alert("チームの作成に失敗しました");
+    }
   }
 
   return (

--- a/src/components/CreateTeamModal.tsx
+++ b/src/components/CreateTeamModal.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Modal from "react-modal";
+import { createTeam } from "../database/Team";
+import { useNavigate } from "react-router-dom";
+import userData from "../sampleData/userData.json";
 
 const customStyles = {
   overlay: {
@@ -30,6 +33,19 @@ const CreateTeamModal: React.FC = () => {
     setIsOpen(false);
   }
 
+  const navigate = useNavigate();
+  async function handleTeamCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const teamName = form.get("teamName");
+    if (teamName === null) {
+      return alert("チーム名を入力してください");
+    }
+
+    const { id } = await createTeam(teamName.toString(), userData);
+    return navigate(`/team/${id}`, { state: teamName });
+  }
+
   return (
     <div className="">
       <button
@@ -49,7 +65,11 @@ const CreateTeamModal: React.FC = () => {
             ×
           </button>
           <h2 className="font-bold text-2xl text-center">チーム作成</h2>
-          <form action="" className="flex flex-col gap-8 mt-8 items-center">
+          <form
+            action=""
+            className="flex flex-col gap-8 mt-8 items-center"
+            onSubmit={(event) => handleTeamCreate(event)}
+          >
             <label htmlFor="teamName" className="flex flex-col gap-2">
               チーム名
               <input

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import { AuthContextProvider } from "./utils/AuthContext.tsx";
 
 const router = createBrowserRouter([
   { path: "/", element: <Home /> },
-  { path: "/team", element: <Team /> },
+  { path: "/team/:id", element: <Team /> },
 ]);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -3,13 +3,14 @@ import MeetingCard from "../components/MeetingCard";
 import { useLocation } from "react-router-dom";
 
 const Team: React.FC = () => {
-  const teamName = useLocation().state;
+  const locationState = useLocation().state;
+  const teamName = locationState.state;
 
   const urlCopyHandler = async (url: string) => {
     try {
       await navigator.clipboard.writeText(url);
     } catch {
-      console.error("URLのコピーに失敗しました");
+      alert("URLのコピーに失敗しました");
     }
   };
 

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -1,10 +1,23 @@
 import React from "react";
 import MeetingCard from "../components/MeetingCard";
+import { useLocation } from "react-router-dom";
 
 const Team: React.FC = () => {
+  const teamName = useLocation().state;
+
+  const urlCopyHandler = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      console.error("URLのコピーに失敗しました");
+    }
+  };
+
   return (
     <div>
-      team
+      team:{teamName}
+      <div>{location.href}</div>
+      <button onClick={() => urlCopyHandler(location.href)}>copy</button>
       <div className="max-w-[900px] mx-auto mt-10 mb-20">
         <h2 className="text-2xl font-bold">会議一覧</h2>
         <div className=" bg-neutral-300 py-12 px-12 rounded-md mt-2 space-y-10">

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -3,7 +3,7 @@ import MeetingCard from "../components/MeetingCard";
 import { useLocation } from "react-router-dom";
 
 const Team: React.FC = () => {
-  const locationState = useLocation().state;
+  const locationState = useLocation();
   const teamName = locationState.state;
 
   const urlCopyHandler = async (url: string) => {

--- a/src/sampleData/userData.json
+++ b/src/sampleData/userData.json
@@ -1,0 +1,6 @@
+{
+  "id": "1",
+  "userId": "1",
+  "name": "string",
+  "iconUrl": "string"
+}


### PR DESCRIPTION
作成ボタンを押したらteamのページに遷移
urlのコピー機能も実装

チームのページのURLがteam/:idに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new modal for creating teams, allowing users to name and create teams directly from the interface.
	- Implemented navigation to a team's page immediately after its creation.
	- Updated team page to display the team name, provide the current URL, and include a button to copy the URL to the clipboard.

- **Enhancements**
	- Modified the route configuration to support dynamic team IDs, enhancing URL structure for team pages.

- **Data**
	- Introduced a new data structure for storing user information, enhancing user management and display capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->