### PR TITLE
チーム作成時にモックを参照してチームのメンバーidが定義されていたものを実際にデータベース上に存在するチーム作成したユーザーを定義するようにした

### DIFF
--- a/src/components/CreateTeamModal.tsx
+++ b/src/components/CreateTeamModal.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import Modal from "react-modal";
 import { createTeam } from "../database/Team";
 import { useNavigate } from "react-router-dom";
-import userData from "../sampleData/userData.json";
+// import userData from "../sampleData/userData.json";
+import { useAuthContext } from "../utils/AuthContext";
 
 const customStyles = {
   overlay: {
@@ -24,7 +25,8 @@ Modal.setAppElement("#root");
 
 const CreateTeamModal: React.FC = () => {
   const [modalIsOpen, setIsOpen] = React.useState(false);
-
+  const { user } = useAuthContext()
+  console.log(user,"user")
   function openModal() {
     setIsOpen(true);
   }
@@ -37,13 +39,20 @@ const CreateTeamModal: React.FC = () => {
   async function handleTeamCreate(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const form = new FormData(event.currentTarget);
-    
+    const userData = {
+      "id":user?.uid || "",
+      "userId":user?.uid|| "",
+      "name":user?.displayName|| "",
+      "iconUrl":user?.photoURL|| ""
+    }
+    console.log(userData)
     const teamName = form.get("teamName");
     if (teamName === null) {
       return alert("チーム名を入力してください");
     }
 
     try {
+      
       const { id } = await createTeam(teamName.toString(), userData);
       console.log("Created team:", id);
       return navigate(`/team/${id}`, { state: teamName });

--- a/src/components/MeetingCard.tsx
+++ b/src/components/MeetingCard.tsx
@@ -1,6 +1,5 @@
 
 const MeetingCard = (props:any) => {
-  console.log(props.detail)
   return (
 
     <div className=" bg-white  rounded-lg">
@@ -13,7 +12,6 @@ const MeetingCard = (props:any) => {
           <p className="text-xl mb-1">メンバー：
           {
             props.detail.members.map((member:any)=>{
-              console.log(member)
               return(`${member},`)
             }
             )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,7 +30,6 @@ const Home: React.FC = () => {
   const onClickLogout = () => {
     auth.logout();
   };
-
   const [teams, setTeams] = useState<team[]>();
   const [userMeetings,setUserMeetings] = useState<meeting[]>();
   const userId = "2";
@@ -45,6 +44,7 @@ const Home: React.FC = () => {
     } 
     ).flat(1);
     setUserMeetings(userMeetingList);
+    console.log(auth.user?.displayName)
   }, []);
 
   return (
@@ -60,6 +60,7 @@ const Home: React.FC = () => {
         <br />
         <div />
         <div className="max-w-[900px] mx-auto mt-10">
+          
           <CreateTeamModal></CreateTeamModal>
           <div className="mt-10">
             <h2 className="text-2xl font-bold">入っているチーム一覧</h2>
@@ -74,7 +75,6 @@ const Home: React.FC = () => {
               <div className=" bg-neutral-300 py-12 px-12 rounded-md mt-2 space-y-10">
                 {
                   userMeetings ? userMeetings.map((meeting)=>{
-                    console.log(meeting)
                     return (
                     <MeetingCard  detail={meeting}></MeetingCard>
                   )

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -18,7 +18,6 @@ const Team: React.FC = () => {
     let teamid = "1";
     const teamData = data;
     const MeetingList = teamData.filter((data) => data.id === teamid);
-    console.log(MeetingList[0].meetings)
     setMeetings(MeetingList[0].meetings)
   }, []);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `Create Team` modal that utilizes user information for team creation.
	- Introduced a new component in the Home page for better user interaction.

- **Bug Fixes**
	- Removed unnecessary console log statements from `MeetingCard` and `Team` pages to clean up the output and enhance performance.

- **Refactor**
	- Adjusted the JSX structure in the Home page for improved readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->