### PR TITLE
44 create team with user info

### DIFF
--- a/src/components/CreateTeamModal.tsx
+++ b/src/components/CreateTeamModal.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Modal from "react-modal";
 import { createTeam } from "../database/Team";
 import { useNavigate } from "react-router-dom";
-// import userData from "../sampleData/userData.json";
+import userData from "../sampleData/userData.json";
 import { useAuthContext } from "../utils/AuthContext";
+import { getUserFromUid } from "../database/User";
+import { User } from "../types";
 
 const customStyles = {
   overlay: {
@@ -25,6 +27,7 @@ Modal.setAppElement("#root");
 
 const CreateTeamModal: React.FC = () => {
   const [modalIsOpen, setIsOpen] = React.useState(false);
+  const [userinfo,setUserinfo] = React.useState<User>();
   const { user } = useAuthContext()
   console.log(user,"user")
   function openModal() {
@@ -34,31 +37,41 @@ const CreateTeamModal: React.FC = () => {
   function closeModal() {
     setIsOpen(false);
   }
+  useEffect(()=> {
+    (async ()=> {
+      console.log(user)
+    if(user){
+      const userinfo = await getUserFromUid(user.uid)
+      console.log(userinfo,"id")
+      setUserinfo(userinfo)
+    }
+    })()
+  },[])
 
   const navigate = useNavigate();
   async function handleTeamCreate(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const form = new FormData(event.currentTarget);
-    const userData = {
-      "id":user?.uid || "",
-      "userId":user?.uid|| "",
-      "name":user?.displayName|| "",
-      "iconUrl":user?.photoURL|| ""
-    }
-    console.log(userData)
+    
+    
+    
+    
+    console.log(userinfo, "userinfo")
     const teamName = form.get("teamName");
     if (teamName === null) {
       return alert("チーム名を入力してください");
     }
 
-    try {
+    if(userinfo){
+      try {
       
-      const { id } = await createTeam(teamName.toString(), userData);
-      console.log("Created team:", id);
-      return navigate(`/team/${id}`, { state: teamName });
-    } catch (error) {
-      console.error("Failed to create team:", error);
-      alert("チームの作成に失敗しました");
+        const { id } = await createTeam(teamName.toString(), userinfo);
+        console.log("Created team:", id);
+        return navigate(`/team/${id}`, { state: teamName });
+      } catch (error) {
+        console.error("Failed to create team:", error);
+        alert("チームの作成に失敗しました");
+      }
     }
   }
 

--- a/src/components/CreateTeamModal.tsx
+++ b/src/components/CreateTeamModal.tsx
@@ -29,7 +29,6 @@ const CreateTeamModal: React.FC = () => {
   const [modalIsOpen, setIsOpen] = React.useState(false);
   const [userinfo,setUserinfo] = React.useState<User>();
   const { user } = useAuthContext()
-  console.log(user,"user")
   function openModal() {
     setIsOpen(true);
   }
@@ -39,10 +38,9 @@ const CreateTeamModal: React.FC = () => {
   }
   useEffect(()=> {
     (async ()=> {
-      console.log(user)
+
     if(user){
       const userinfo = await getUserFromUid(user.uid)
-      console.log(userinfo,"id")
       setUserinfo(userinfo)
     }
     })()
@@ -52,11 +50,6 @@ const CreateTeamModal: React.FC = () => {
   async function handleTeamCreate(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const form = new FormData(event.currentTarget);
-    
-    
-    
-    
-    console.log(userinfo, "userinfo")
     const teamName = form.get("teamName");
     if (teamName === null) {
       return alert("チーム名を入力してください");


### PR DESCRIPTION
[チームを作成時にモックではなくユーザーの情報を定義する](https://github.com/PoPodada/Progate-hakkason/issues/44#top)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the team creation modal to automatically fetch and use up-to-date user information.
- **Refactor**
	- Updated state management and logic in the team creation process for improved accuracy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->